### PR TITLE
minor fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cd pacli && chmod +x pacli && ./pacli
 ## Help
 
 ### pacli Help
-Choose the "Help" option in pacli by entering "16" and pressing "ENTER". 
+Choose the "Help" option in pacli by entering "10" and pressing "ENTER".
 
 This help page explains a little bit about pacli. It also explains every pacli option in detail. If you want to look up which commands pacli uses and understand them, this is the right place for you!
 

--- a/pacli
+++ b/pacli
@@ -48,8 +48,10 @@ catplus()
 help_text()
 {
     local id="${1:-0}" command="less -R"
-    local help="/usr/share/doc/pacli/help"
-    [ -f "$help" ] || help="./pacli.help" # for devs or manual install
+    local help="./pacli.${LANG:0:2}.help"   # first for devs or manual install
+    [ -f "$help" ] || help="/usr/share/doc/pacli/${LANG:0:2}.help"
+    help="./pacli.help"
+    [ -f "$help" ] || help="/usr/share/doc/pacli/help"
     ((id>0)) && command='cat'
     catplus "$help" "$id" | $command
 }
@@ -208,7 +210,7 @@ NC='\e[0m'
         14)
             echo
             [[ -z "$EDITOR" ]] && EDITOR='nano'
-            $EDITOR /etc/pacman.conf
+            sudo $EDITOR /etc/pacman.conf
             read
             ;;
         15)


### PR DESCRIPTION
sudo for edit
10 help in readme

4 search locale and local for help in this order: 

```
./pacli.${LANG:0:2}.help  
/usr/share/doc/pacli/${LANG:0:2}.help
./pacli.help 
/usr/share/doc/pacli/help
```

now it's good for internationalize this file
