### PR TITLE
Fix some AUR packages not being listed and minor clean up

### DIFF
--- a/pacli
+++ b/pacli
@@ -123,8 +123,18 @@ libfile="./lib/helper-${PARAMS['helper']}.sh"
 # write package list of repositories to /tmp/packages. then, download AUR package list, unzip it to /tmp/aur/packages, and add it to the bottom of /tmp/packages.
 load_packages_infos()
 {
-    helper -Slq 2>/dev/null 1>/tmp/packages &
-    wget -P /tmp/aur/ https://aur.archlinux.org/packages.gz >/dev/null 2>&1 && cat /tmp/aur/packages.gz >> /tmp/packages &
+    [[ $run_info_once == "True" ]] && return
+
+    helper -Slq 2>/dev/null 1>/tmp/packages
+    clear
+    echo
+    echo "Updating AUR package info... Please Wait"
+    echo
+    wget -q -P /tmp/aur/ https://aur.archlinux.org/packages.gz >/dev/null 2>&1
+    [[ -e /tmp/aur/packages ]] && rm -f /tmp/aur/packages
+    gunzip /tmp/aur/packages.gz
+    cat /tmp/aur/packages >> /tmp/packages
+    run_info_once="True"
 }
 
 ########    pacman    ######
@@ -133,6 +143,7 @@ load_packages_infos()
 package_information()
 {
     declare pkg='' cmd='Sii' out
+    load_packages_infos
     pacman -Qq > /tmp/local_packages
     cat /tmp/packages /tmp/local_packages | sort -u | uniq > /tmp/all_packages
 
@@ -248,6 +259,7 @@ informations ()
 {
     declare mybranch myrepo myurl testfile
     declare -i pacnews=0 pacsaves=0
+    load_packages_infos
     mybranch=$(awk -F'=' '/^Branch/ {print $2}' /etc/pacman-mirrors.conf)
     [ -z "$mybranch" ] && mybranch='stable'
     myrepo=$(awk -F'=' '/^Server/ {print $2}' /etc/pacman.d/mirrorlist | head -n 1)
@@ -382,20 +394,19 @@ main()
             sudo pacman-mirrors -g && sudo pacman -Syy --color always
             helper -Qdt
             paccache -ruvk0
-            paccache -rvk2
-			
-			disk=$(lsblk -o "name,mountpoint" -pa | sed -n '/^\//h;/\/$/{g;p}' | cut -d/ -f3)
-			disk="${disk:0:3}"
-			if [[ -n "$disk" && -e "/dev/$disk" ]]; then
-                [[ $(cat $(find /sys -name 'rotational' 2>/dev/null | grep "$disk/queue")) == "1" ]] \
-                    && sudo pacman-optimize
-			fi
-			unset disk
-			
-			echo
+            paccache -rvk2		
+            disk=$(lsblk -o "name,mountpoint" -pa | sed -n '/^\//h;/\/$/{g;p}' | cut -d/ -f3)
+            disk="${disk:0:3}"
+            if [[ -n "$disk" && -e "/dev/$disk" ]]; then
+                if [[ $(cat $(find /sys -name 'rotational' 2>/dev/null | grep "$disk/queue")) == "1" ]]; then
+                    sudo pacman-optimize
+                fi
+            fi
+            unset disk
+            echo
             print_hook
             print_prompt "$(gettext 'System is updated and cache is cleaned')." "" 1
-			;;
+	    ;;
         3)
             echo
             pkg=($(print_enter "$(gettext 'Select packages to install (use TAB to toggle selection)')" \
@@ -453,7 +464,7 @@ main()
             ;;
         12)
             echo
-			$(print_enter "$(gettext 'Enter one or more filter terms')" "$(tail -2000 /var/log/pacman.log)" '-m +s -q alpm --tac' ) >> /tmp/pacli-log			
+            $(print_enter "$(gettext 'Enter one or more filter terms')" "$(tail -2000 /var/log/pacman.log)" '-m +s -q alpm --tac' ) >> /tmp/pacli-log			
             ;;
         13)
             help_text $choix "${PARAMS['helpred']}" || continue
@@ -522,7 +533,7 @@ main()
             print_prompt "$(gettext 'AUR Helper finished')." "" 1
             ;;
         22)
-            echo
+	    load_package_info
             pkg=($(print_enter "$(gettext 'Select packages to install (toggle selection with TAB)')" \
                 "$(cat /tmp/packages)" '-m' ))
             (($?!=0)) && continue
@@ -583,7 +594,6 @@ main()
 }
 
 if [ "${BASH_SOURCE[0]}" == "$0" ]; then
-    load_packages_infos
     #make home screen
     declare -r screen_buffer=$(menu_load)
     #loop menu


### PR DESCRIPTION
Currently many packages don't show up when using option 22, `wget` cannot be backgrounded with `&` or the following `cat` will fail or miss packages. With this the package info is only loaded when needed and only ever loaded once regardless, this keeps the startup of pacli quick but when searching for AUR packages or other steps that need it, the info is loaded along with a message regarding the delay

I also just cleaned up a bit of indentation in `main()`

Cheers